### PR TITLE
Add ltrace to distribution

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,11 +12,14 @@
     packages.x86_64-linux = let
       pkgs = nixpkgs.legacyPackages.x86_64-linux;
       hyperfsFromPkgs = pkgs: pkgs.callPackage ./src/hyperfs { inherit libhc; };
+      ltraceFromPkgs = pkgs: pkgs.callPackage ./src/ltrace { };
     in rec {
       hyperfs = hyperfsFromPkgs pkgs;
+      ltrace = ltraceFromPkgs pkgs;
       all-archs = import ./src/build-all-archs.nix { inherit pkgs nixpkgs; }
         (pkgs: [
           (hyperfsFromPkgs pkgs)
+          (ltraceFromPkgs pkgs)
           (pkgs.bash // { iglooName = "bash-unwrapped"; })
           (pkgs.strace.override { libunwind = null; })
           (pkgs.gdbHostCpuOnly.overrideAttrs (self: {

--- a/src/ltrace/default.nix
+++ b/src/ltrace/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, fetchgit, autoreconfHook, libelf }:
+
+stdenv.mkDerivation {
+  name = "igloo-ltrace";
+  src = fetchFromGitHub {
+    owner = "sparkleholic";
+    repo = "ltrace";
+    rev = "c22d359433b333937ee3d803450dc41998115685";
+    sha256 = "sha256-FOS6CUIR+C86m5xS+OnRjrVDszQuZb6iamc8UTCKrkk=";
+  };
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ libelf ];
+  prePatch = let
+    meta-openembedded = fetchgit {
+      url = "https://git.openembedded.org/meta-openembedded";
+      rev = "01d3dca6e991e7da7ea9f181a75536a430e1bece";
+      sha256 = "sha256-EzTKswrCsg4cp0Jd0fRRjqjBZeX4/0YMey2PKk5U7ps=";
+    };
+  in ''
+    patches="${meta-openembedded}/meta-oe/recipes-devtools/ltrace/ltrace/*.patch $patches"
+    mkdir -p config/{autoconf,m4}
+  '';
+  meta.mainProgram = "ltrace";
+}


### PR DESCRIPTION
This builds successfully, but the binaries don't seem to actually work. It might be worth trying to patch the Fedora version to work with musl and other architectures, instead of using Yocto's ltrace.