### PR TITLE
fix: Use real getattr for dev/proc/sys directories instead of hypercall

### DIFF
--- a/src/pkgs/hyperfs/hyperfs.c
+++ b/src/pkgs/hyperfs/hyperfs.c
@@ -180,7 +180,9 @@ static int hyperfs_getattr(const char *path, struct stat *st,
   (void)fi;
   int mode = lookup_mode(path);
 
-  if (mode >= 0) {
+  bool base_dir = strcmp(path, "/dev") == 0 || strcmp(path, "/proc") == 0 || strcmp(path, "/sys") == 0;
+
+  if (mode >= 0 && !base_dir) {
     memset(st, 0, sizeof(struct stat));
     st->st_nlink = !strcmp(path, "/") ? 2 : 1;
     st->st_mode = mode;


### PR DESCRIPTION
Previously we'd issue hypercalls to model `getattr` behavior on the /proc /dev and /sys directories which would trigger warnings and probably incorrect behavior - this PR changes it to use the real getattr logic for those directories.

I'd be open to doing this in a more generic way - e.g., if there's only a single `/` in the path use real getattr? Or we can hardcode it like this 🤷‍♂️ 